### PR TITLE
enhancement: added optional confirmation for task deletion and updated task IDs to be reusable

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ tix undo 1
 # Remove a single task
 tix rm 1
 
+# Force remove a single task
+tix rm 2 --confirm
+
 # Clear all completed tasks
 tix clear --completed
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,5 +1,6 @@
 import pytest
 import tempfile
+import json
 from pathlib import Path
 from tix.storage.json_storage import TaskStorage
 
@@ -22,11 +23,15 @@ def test_add_task(temp_storage):
     assert task.priority == "high"
     assert "work" in task.tags
 
+    task2 = temp_storage.add_task("Another task")
+    assert task2.id == 2
+
 
 def test_get_task(temp_storage):
     """Test retrieving a task"""
     task = temp_storage.add_task("Test")
     retrieved = temp_storage.get_task(task.id)
+    assert retrieved is not None
     assert retrieved.id == task.id
     assert retrieved.text == "Test"
 
@@ -34,8 +39,11 @@ def test_get_task(temp_storage):
 def test_delete_task(temp_storage):
     """Test deleting a task"""
     task = temp_storage.add_task("To delete")
-    assert temp_storage.delete_task(task.id) == True
+    assert temp_storage.delete_task(task.id) is True
     assert temp_storage.get_task(task.id) is None
+
+    new_task = temp_storage.add_task("New after delete")
+    assert new_task.id > task.id
 
 
 def test_update_task(temp_storage):
@@ -45,4 +53,24 @@ def test_update_task(temp_storage):
     temp_storage.update_task(task)
 
     retrieved = temp_storage.get_task(task.id)
+    assert retrieved is not None
     assert retrieved.text == "Updated"
+
+
+def test_backward_compatibility(temp_storage):
+    """Test reading old format (plain list) and upgrading"""
+    old_data = [{"id": 5, "text": "legacy", "priority": "low", "tags": [], "completed": False}]
+    temp_storage.storage_path.write_text(json.dumps(old_data))
+
+    tasks = temp_storage.load_tasks()
+    assert len(tasks) == 1
+    assert tasks[0].id == 5
+    assert tasks[0].text == "legacy"
+
+    new_task = temp_storage.add_task("post-upgrade")
+    assert new_task.id == 6
+
+    data = json.loads(temp_storage.storage_path.read_text())
+    assert isinstance(data, dict)
+    assert "next_id" in data
+    assert "tasks" in data

--- a/tix/cli.py
+++ b/tix/cli.py
@@ -83,12 +83,17 @@ def done(task_id):
 
 @cli.command()
 @click.argument('task_id', type=int)
-def rm(task_id):
+@click.option("--confirm", is_flag=True, help="Force deleting a task")
+def rm(task_id,confirm):
     """Remove a task"""
     task = storage.get_task(task_id)
     if not task:
         console.print(f"[red]✗[/red] Task #{task_id} not found")
         return
+    if not confirm:
+        if not click.confirm(f"Are you sure you want to delete task #{task_id}: '{task.text}'?"):
+            console.print("[yellow]⚠ Cancelled[/yellow]")
+            return
 
     if storage.delete_task(task_id):
         console.print(f"[red]✗[/red] Removed: {task.text}")


### PR DESCRIPTION
## PR Checklist
- [X] Follows single-purpose principle
- [X] Tests pass locally
- [X] Documentation updated (if needed)

## What does this PR do?
<!-- Brief description -->
1.  Added a ```--confirm``` flag to ```rm``` to force delete a task, using only ```rm``` will now ask for confirmation
2. Task IDs are now unique across the lifetime of the task file, when all tasks are deleted and a new task is added the new task will now have its own id and not start again form 1

## Related Issue
Closes #21
Closes #14

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Configuration
- [X] Documentation
