### PR TITLE
fix: validate empty task text in add command

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,6 +85,36 @@ def test_add_and_list(runner):
             assert 'My task' in result.output or 'high' in result.output
 
 
+def test_add_empty_task_text(runner):
+    """Empty task text should be rejected"""
+    with runner.isolated_filesystem():
+        temp_storage = Path.cwd() / "tasks.json"
+        temp_storage.write_text('[]')
+
+        from tix.storage.json_storage import TaskStorage
+        test_storage = TaskStorage(temp_storage)
+
+        with patch('tix.cli.storage', test_storage):
+            result = runner.invoke(cli, ['add', ''])
+            assert result.exit_code != 0
+            assert 'cannot be empty' in result.output
+
+
+def test_add_whitespace_only_task_text(runner):
+    """Whitespace-only task text should be rejected"""
+    with runner.isolated_filesystem():
+        temp_storage = Path.cwd() / "tasks.json"
+        temp_storage.write_text('[]')
+
+        from tix.storage.json_storage import TaskStorage
+        test_storage = TaskStorage(temp_storage)
+
+        with patch('tix.cli.storage', test_storage):
+            result = runner.invoke(cli, ['add', '   \t   '])
+            assert result.exit_code != 0
+            assert 'cannot be empty' in result.output
+
+
 def test_done_command(runner):
     """Test marking a task as done"""
     with runner.isolated_filesystem():

--- a/tix/cli.py
+++ b/tix/cli.py
@@ -36,6 +36,10 @@ def cli(ctx):
 @click.option('--tag', '-t', multiple=True, help='Add tags to task')
 def add(task, priority, tag):
     """Add a new task"""
+    if not task or not task.strip():
+        console.print("[red]✗[/red] Task text cannot be empty")
+        sys.exit(1)
+
     new_task = storage.add_task(task, priority, list(tag))
     color = {'high': 'red', 'medium': 'yellow', 'low': 'green'}[priority]
     console.print(f"[green]✔[/green] Added task #{new_task.id}: [{color}]{task}[/{color}]")


### PR DESCRIPTION
fixes #44

## PR Checklist
- [x] Follows single-purpose principle
- [x] Tests pass locally
- [x] Documentation updated (if needed)

## What does this PR do?
Adds validation to the `add` command to reject empty or whitespace-only task text.

The command now checks `if not task.strip():` and shows an error message before exiting with a non-zero status.

Includes tests for empty and whitespace-only inputs.

## Related Issue
Closes #44

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Configuration
- [ ] Documentation

## Screenshot(s)
<img width="1761" height="1682" alt="image" src="https://github.com/user-attachments/assets/5559d50d-8d4e-458a-b772-fa3f545ec60c" />