### PR TITLE
feat: add support for task attachments and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ tix add "My task"  # Start managing tasks!
 - **Colored Output**: Beautiful terminal UI with rich formatting
 - **Bulk Operations**: Mark multiple tasks as done at once
 - **Auto Shell Completion**: Tab completion works out of the box for bash, zsh, and fish
+- **Attachments & Links**: Attach files or add reference URLs to tasks
+- **Open Attachments**: Use `tix open <id>` to quickly open all files/links for a task
 
 ## 📖 Installation Methods
 
@@ -176,6 +178,12 @@ tix add "Review PR" -t work -t urgent
 
 # Multiple tags and priority
 tix add "Deploy to production" -p high -t devops -t release
+
+# With file attachments (can repeat)
+tix add "Review design doc" -f ~/docs/design.pdf -f ~/notes.txt
+
+# With reference links (can repeat)
+tix add "Research API" -l https://api.example.com -l https://swagger.io
 ```
 
 #### Listing Tasks
@@ -235,6 +243,9 @@ tix edit 1 --add-tag urgent --remove-tag low-priority
 
 # Multiple edits at once
 tix edit 1 --text "New text" --priority high --add-tag important
+
+# Add attachments and links to an existing task
+tix edit 1 -f ~/extra.docx -l https://extra-resource.com
 ```
 
 #### Searching and Filtering
@@ -259,6 +270,13 @@ tix tags
 
 # Show untagged tasks
 tix tags --no-tags
+```
+
+#### Opening Attachments and Links
+
+```bash
+# Open all files and links attached to a task
+tix open 1
 ```
 
 #### Statistics and Reports
@@ -326,13 +344,13 @@ Example structure:
 
 | Command | Description | Example |
 |---------|-------------|---------|
-| `add` | Add a new task | `tix add "Task" -p high -t work` |
+| `add` | Add a new task | `tix add "Task" -p high -t work -f file.txt -l https://example.com` |
 | `ls` | List tasks | `tix ls --all` |
 | `done` | Complete a task | `tix done 1` |
 | `done-all` | Complete multiple tasks | `tix done-all 1 2 3` |
 | `rm` | Remove a task | `tix rm 1 -y` |
 | `clear` | Clear tasks in bulk | `tix clear --completed` |
-| `edit` | Edit task properties | `tix edit 1 --text "New"` |
+| `edit` | Edit task properties | `tix edit 1 --text "New" -f notes.md -l https://example.com` |
 | `priority` | Change task priority | `tix priority 1 high` |
 | `move` | Change task ID | `tix move 1 10` |
 | `undo` | Reactivate completed task | `tix undo 1` |
@@ -341,6 +359,7 @@ Example structure:
 | `tags` | List all tags | `tix tags` |
 | `stats` | Show statistics | `tix stats -d` |
 | `report` | Generate report | `tix report -f json -o tasks.json` |
+| `open` | Open attachments and links for a task | `tix open 1` |
 
 ## 🗑️ Uninstalling TIX
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -153,3 +153,105 @@ def test_filter_command(runner):
             assert result.exit_code == 0
             assert 'Active task' in result.output
             assert 'Completed task' not in result.output
+            
+
+def test_add_task_with_attachments_and_links(runner, tmp_path):
+    """Test adding a task with file attachments and URLs"""
+    # Create a temporary file to attach
+    temp_file = tmp_path / "example.txt"
+    temp_file.write_text("Hello World")
+
+    temp_storage = tmp_path / "tasks.json"
+    temp_storage.write_text('[]')
+
+    from tix.storage.json_storage import TaskStorage
+    test_storage = TaskStorage(temp_storage)
+
+    with patch('tix.cli.storage', test_storage):
+        result = runner.invoke(cli, [
+            'add', 'Task with attachments',
+            '--attach', str(temp_file),
+            '--link', 'https://example.com'
+        ])
+        assert result.exit_code == 0
+        assert 'Added task' in result.output
+        assert 'Attachments/Links added' in result.output
+
+        # Verify task in storage
+        task = test_storage.get_task(1)
+        assert task is not None
+        assert len(task.attachments) == 1
+        assert task.links == ['https://example.com']
+
+
+def test_edit_task_add_attachments_and_links(runner, tmp_path):
+    """Test editing an existing task to add attachments and URLs"""
+    temp_file = tmp_path / "edit.txt"
+    temp_file.write_text("Edit content")
+
+    temp_storage = tmp_path / "tasks.json"
+    temp_storage.write_text(
+        '[{"id": 1, "text": "Original task", "priority": "medium", "completed": false, "created_at": "2025-01-01T00:00:00", "completed_at": null, "tags": []}]'
+    )
+
+    from tix.storage.json_storage import TaskStorage
+    test_storage = TaskStorage(temp_storage)
+
+    with patch('tix.cli.storage', test_storage):
+        result = runner.invoke(cli, [
+            'edit', '1',
+            '--attach', str(temp_file),
+            '--link', 'https://edit.com'
+        ])
+        assert result.exit_code == 0
+        assert 'attachments added' in result.output
+        assert 'links added' in result.output
+
+        task = test_storage.get_task(1)
+        assert len(task.attachments) == 1
+        assert task.links == ['https://edit.com']
+
+
+def test_ls_shows_attachment_icon(runner, tmp_path):
+    """Test that tasks with attachments/links show the 📎 icon"""
+    temp_storage = tmp_path / "tasks.json"
+    temp_storage.write_text(
+        '[{"id": 1, "text": "Task with attachment", "priority": "medium", "completed": false, "created_at": "2025-01-01T00:00:00", "completed_at": null, "tags": [], "attachments": ["file.txt"], "links": ["https://example.com"]}]'
+    )
+
+    from tix.storage.json_storage import TaskStorage
+    test_storage = TaskStorage(temp_storage)
+
+    with patch('tix.cli.storage', test_storage):
+        result = runner.invoke(cli, ['ls'])
+        assert result.exit_code == 0
+        assert '📎' in result.output
+
+
+def test_open_command_opens_attachments_and_links(runner, tmp_path):
+    """Test opening attachments and links without actually launching them"""
+    temp_file = tmp_path / "open.txt"
+    temp_file.write_text("Open me")
+
+    temp_storage = tmp_path / "tasks.json"
+    temp_storage.write_text(
+        f'[{{"id": 1, "text": "Task to open", "priority": "medium", "completed": false, '
+        f'"created_at": "2025-01-01T00:00:00", "completed_at": null, "tags": [], '
+        f'"attachments": ["{temp_file}"], "links": ["https://example.com"]}}]'
+    )
+
+    from tix.storage.json_storage import TaskStorage
+    test_storage = TaskStorage(temp_storage)
+
+    with patch('tix.cli.storage', test_storage), \
+         patch('subprocess.Popen') as mock_popen, \
+         patch('os.startfile', create=True):
+
+        result = runner.invoke(cli, ['open', '1'])
+        assert result.exit_code == 0
+        assert 'Opened file' in result.output
+        assert 'Opened link' in result.output
+
+        # Ensure the link was opened (regardless of platform details)
+        calls = [str(call_args[0][0][1]) for call_args in mock_popen.call_args_list]
+        assert "https://example.com" in calls

--- a/tix/cli.py
+++ b/tix/cli.py
@@ -4,8 +4,11 @@ from rich.table import Table
 from pathlib import Path
 from tix.storage.json_storage import TaskStorage
 from datetime import datetime
+import subprocess
+import platform
 import os
 import sys
+
 
 # Initialize console and storage
 console = Console()
@@ -34,13 +37,40 @@ def cli(ctx):
               type=click.Choice(['low', 'medium', 'high']),
               help='Set task priority')
 @click.option('--tag', '-t', multiple=True, help='Add tags to task')
-def add(task, priority, tag):
+@click.option('--attach', '-f', multiple=True, help='Attach file(s)')
+@click.option('--link', '-l', multiple=True, help='Attach URL(s)')
+def add(task, priority, tag, attach, link):
     """Add a new task"""
     new_task = storage.add_task(task, priority, list(tag))
+
+    # Handle attachments
+    if attach:
+        attachment_dir = Path.home() / ".tix" / "attachments" / str(new_task.id)
+        attachment_dir.mkdir(parents=True, exist_ok=True)
+        for file_path in attach:
+            try:
+                src = Path(file_path).expanduser().resolve()  
+                if not src.exists():
+                    console.print(f"[red]✗[/red] File not found: {file_path}")
+                    continue
+                dest = attachment_dir / src.name
+                dest.write_bytes(src.read_bytes())
+                new_task.attachments.append(str(dest))
+            except Exception as e:
+                console.print(f"[red]✗[/red] Failed to attach {file_path}: {e}")
+
+    # Handle links
+    if link:
+        new_task.links.extend(link)
+
+    storage.update_task(new_task)
+
     color = {'high': 'red', 'medium': 'yellow', 'low': 'green'}[priority]
     console.print(f"[green]✔[/green] Added task #{new_task.id}: [{color}]{task}[/{color}]")
     if tag:
         console.print(f"[dim]  Tags: {', '.join(tag)}[/dim]")
+    if attach or link:
+        console.print(f"[dim]  Attachments/Links added[/dim]")
 
 
 @cli.command()
@@ -65,12 +95,15 @@ def ls(all):
         priority_color = {'high': 'red', 'medium': 'yellow', 'low': 'green'}[task.priority]
         tags_str = ", ".join(task.tags) if task.tags else ""
 
+        # Show paperclip if task has attachments or links
+        attach_icon = " 📎" if task.attachments or task.links else ""
+
         task_style = "dim strike" if task.completed else ""
         table.add_row(
             str(task.id),
             status,
             f"[{priority_color}]{task.priority}[/{priority_color}]",
-            f"[{task_style}]{task.text}[/{task_style}]" if task.completed else task.text,
+            f"[{task_style}]{task.text}[/{task_style}]{attach_icon}" if task.completed else f"{task.text}{attach_icon}",
             tags_str
         )
 
@@ -214,7 +247,9 @@ def done_all(task_ids):
 @click.option('--priority', '-p', type=click.Choice(['low', 'medium', 'high']), help='New priority')
 @click.option('--add-tag', multiple=True, help='Add tags')
 @click.option('--remove-tag', multiple=True, help='Remove tags')
-def edit(task_id, text, priority, add_tag, remove_tag):
+@click.option('--attach', '-f', multiple=True, help='Attach file(s)')
+@click.option('--link', '-l', multiple=True, help='Attach URL(s)')
+def edit(task_id, text, priority, add_tag, remove_tag, attach, link):
     """Edit a task"""
     task = storage.get_task(task_id)
     if not task:
@@ -242,6 +277,22 @@ def edit(task_id, text, priority, add_tag, remove_tag):
         if tag in task.tags:
             task.tags.remove(tag)
             changes.append(f"-tag: '{tag}'")
+
+    # Handle attachments
+    if attach:
+        attachment_dir = Path.home() / ".tix/attachments" / str(task.id)
+        attachment_dir.mkdir(parents=True, exist_ok=True)
+        for file_path in attach:
+            src = Path(file_path)
+            dest = attachment_dir / src.name
+            dest.write_bytes(src.read_bytes())
+            task.attachments.append(str(dest))
+        changes.append(f"attachments added: {[Path(f).name for f in attach]}")
+
+    # Handle links
+    if link:
+        task.links.extend(link)
+        changes.append(f"links added: {list(link)}")
 
     if changes:
         storage.update_task(task)
@@ -543,6 +594,59 @@ def report(format, output):
         console.print(f"[green]✔[/green] Report saved to {output}")
     else:
         console.print(report_text)
+
+
+@cli.command()
+@click.argument('task_id', type=int)
+def open(task_id):
+    """Open all attachments and links for a task"""
+    task = storage.get_task(task_id)
+    if not task:
+        console.print(f"[red]✗[/red] Task #{task_id} not found")
+        return
+
+    if not task.attachments and not task.links:
+        console.print(f"[yellow]![/yellow] Task {task_id} has no attachments or links")
+        return
+    
+    # Helper to open files cross-platform
+    def safe_open(path_or_url, is_link=False):
+        """Cross-platform safe opener for files and links (non-blocking)."""
+        system = platform.system()
+
+        try:
+            if system == "Linux":
+                if "microsoft" in platform.release().lower():
+                    subprocess.Popen(["explorer.exe", str(path_or_url)],
+                                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                else:
+                    subprocess.Popen(["xdg-open", str(path_or_url)],
+                                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+            elif system == "Darwin":  # macOS
+                subprocess.Popen(["open", str(path_or_url)],
+                                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+            elif system == "Windows":
+                subprocess.Popen(["explorer.exe", str(path_or_url)],
+                                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+            console.print(f"[green]✔[/green] Opened {'link' if is_link else 'file'}: {path_or_url}")
+
+        except Exception as e:
+            console.print(f"[yellow]![/yellow] Could not open {'link' if is_link else 'file'}: {path_or_url} ({e})")
+
+    # Open attachments
+    for file_path in task.attachments:
+        path = Path(file_path)
+        if not path.exists():
+            console.print(f"[red]✗[/red] File not found: {file_path}")
+            continue
+        safe_open(path)   
+
+    # Open links
+    for url in task.links:
+        safe_open(url, is_link=True)  
 
 
 if __name__ == '__main__':

--- a/tix/models.py
+++ b/tix/models.py
@@ -12,6 +12,8 @@ class Task:
     created_at: str = field(default_factory=lambda: datetime.now().isoformat())
     completed_at: Optional[str] = None
     tags: List[str] = field(default_factory=list)
+    attachments: List[str] = field(default_factory=list)
+    links: List[str] = field(default_factory=list)  
 
     def to_dict(self) -> dict:
         """Convert task to dictionary for JSON serialization"""
@@ -22,13 +24,25 @@ class Task:
             'completed': self.completed,
             'created_at': self.created_at,
             'completed_at': self.completed_at,
-            'tags': self.tags
+            'tags': self.tags,
+            'attachments': self.attachments,
+            'links': self.links,
         }
 
     @classmethod
     def from_dict(cls, data: dict):
-        """Create task from dictionary"""
-        return cls(**data)
+        """Create task from dictionary (handles old tasks safely)"""
+        return cls(
+            id=data['id'],
+            text=data['text'],
+            priority=data.get('priority', 'medium'),
+            completed=data.get('completed', False),
+            created_at=data.get('created_at', datetime.now().isoformat()),
+            completed_at=data.get('completed_at'),
+            tags=data.get('tags', []),
+            attachments=data.get('attachments', []),  
+            links=data.get('links', [])               
+        )
 
     def mark_done(self):
         """Mark task as completed with timestamp"""

--- a/tix/storage/json_storage.py
+++ b/tix/storage/json_storage.py
@@ -109,3 +109,7 @@ class TaskStorage:
     def get_completed_tasks(self) -> List[Task]:
         """Get all completed tasks"""
         return [t for t in self.load_tasks() if t.completed]
+    
+    def get_attachment_dir(self, task_id: int) -> Path:
+        """Return the path where attachments for a task should be stored"""
+        return Path.home() / ".tix" / "attachments" / str(task_id)


### PR DESCRIPTION
closes [#51 ](https://github.com/TheDevOpsBlueprint/tix-cli/issues/51)


This PR adds support for task attachments and links.

### Changes
- Extend Task model (`models.py`) with optional `attachments` and `links`
- Add CLI flags `--attach` and `--link` for `add` and `edit`
- Store file attachments under `~/.tix/attachments/<task_id>/`
- Add `tix open <id>` command to open all attachments and links for a task
- Show 📎 in `ls` when tasks have attachments or links
- Add unit tests (`test_cli.py`) for attachments, links, and open command


### Sample:


https://github.com/user-attachments/assets/1a88b6e3-ac0d-411f-8df4-462c1f32ea93



<img width="1281" height="416" alt="Screenshot 2025-09-30 220352" src="https://github.com/user-attachments/assets/3a2520ca-b049-481c-abcf-574b6ab3ab19" />

