### PR TITLE
feat: add task template feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ tix add "My task"  # Start managing tasks!
 - **Auto Shell Completion**: Tab completion works out of the box for bash, zsh, and fish
 - **Attachments & Links**: Attach files or add reference URLs to tasks
 - **Open Attachments**: Use `tix open <id>` to quickly open all files/links for a task
+- **Task Templates**: Save common tasks as templates and reuse them for quick creation
 
 ## About Interactive (TUI) Mode
 
@@ -350,6 +351,32 @@ tix report -f json -o tasks.json
 tix report --output my-tasks.txt
 ```
 
+#### Task Templates
+
+```bash
+# Save an existing task as a template
+tix template save <task_id> <template_name>
+# Example: save task #2 as 'pr-template'
+tix template save 2 pr-template
+
+# List all saved templates
+tix template list
+
+# Create a new task from a template
+tix add --template <template_name>
+# Example: create a task from 'pr-template'
+tix add --template pr-template
+
+# Override template values when creating a new task
+tix add --template pr-template --priority high --tag urgent
+
+# Templates are stored in ~/.tix/templates/
+
+# If a template does not exist, tix will notify you
+
+# Each add --template creates a new task with the template fields
+```
+
 ## 🎨 Using Tab Completion
 
 Tab completion works automatically after installation:
@@ -410,6 +437,9 @@ Example structure:
 | `stats` | Show statistics | `tix stats -d` |
 | `report` | Generate report | `tix report -f json -o tasks.json` |
 | `open` | Open attachments and links for a task | `tix open 1` |
+| `template save` | Save a task as a template | `tix template save 2 pr-template` |
+| `template list` | List all saved templates | `tix template list` |
+| `add --template` | Create a new task from a template | `tix add --template pr-template -p high -t urgent` |
 
 ## 🗑️ Uninstalling TIX
 

--- a/tests/test_template_storage.py
+++ b/tests/test_template_storage.py
@@ -1,0 +1,46 @@
+import pytest
+from tix.models import Task
+from tix.storage.template_storage import TemplateStorage
+
+
+@pytest.fixture
+def temp_template_dir(tmp_path):
+    """Fixture providing an isolated template storage directory"""
+    storage = TemplateStorage(storage_dir=tmp_path)
+    return storage
+
+
+def test_save_and_load_template(temp_template_dir):
+    """Test saving a template and then loading it"""
+    task = Task(id=1, text="Template task", priority="high", tags=["urgent"], completed=False)
+    task.links = ["https://example.com"]
+
+    temp_template_dir.save_template(task, "my-template")
+    
+    path = temp_template_dir._template_path("my-template")
+    assert path.exists(), "Template file should exist after saving"
+
+    loaded = temp_template_dir.load_template("my-template")
+    assert loaded["text"] == task.text
+    assert loaded["priority"] == task.priority
+    assert loaded["tags"] == list(task.tags)
+    assert loaded["links"] == task.links
+
+
+def test_load_missing_template(temp_template_dir):
+    """Loading a non-existent template should return None"""
+    assert temp_template_dir.load_template("missing") is None
+
+
+def test_list_templates(temp_template_dir):
+    """List all saved templates"""
+    # Save multiple templates
+    task = Task(id=1, text="Task1", priority="low", tags=[])
+    temp_template_dir.save_template(task, "t1")
+    temp_template_dir.save_template(task, "t2")
+    
+    templates = temp_template_dir.list_templates()
+    assert "t1" in templates
+    assert "t2" in templates
+    assert len(templates) == 2
+

--- a/tix/storage/template_storage.py
+++ b/tix/storage/template_storage.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+from typing import List, Optional
+from tix.models import Task
+
+
+class TemplateStorage:
+    """JSON-based storage for task templates"""
+
+    def __init__(self, storage_dir: Path = None):
+        """Initialize template storage with default or custom path"""
+        self.storage_dir = storage_dir or (Path.home() / ".tix" / "templates")
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+
+    def _template_path(self, name: str) -> Path:
+        """Return the full path for a template"""
+        return self.storage_dir / f"{name}.json"
+
+    def save_template(self, task: Task, name: str):
+        """Save only the relevant template fields (no id / timestamps)."""
+        path = self._template_path(name)
+        data = {
+            "text": task.text,
+            "priority": task.priority,
+            "tags": list(task.tags) if task.tags else [],
+            "links": getattr(task, "links", []) or [],
+        }
+        path.write_text(json.dumps(data, indent=2))
+
+    def load_template(self, name: str) -> Optional[Task]:
+        """Load a template by name"""
+        path = self._template_path(name)
+        if not path.exists():
+            return None
+        return json.loads(path.read_text())
+
+    def list_templates(self) -> List[str]:
+        """List all template names"""
+        return [p.stem for p in sorted(self.storage_dir.glob("*.json"))]
+
+    def delete_template(self, name: str) -> bool:
+        """Delete a template by name"""
+        path = self._template_path(name)
+        if path.exists():
+            path.unlink()
+            return True
+        return False

--- a/tix/storage/template_storage.py
+++ b/tix/storage/template_storage.py
@@ -37,11 +37,3 @@ class TemplateStorage:
     def list_templates(self) -> List[str]:
         """List all template names"""
         return [p.stem for p in sorted(self.storage_dir.glob("*.json"))]
-
-    def delete_template(self, name: str) -> bool:
-        """Delete a template by name"""
-        path = self._template_path(name)
-        if path.exists():
-            path.unlink()
-            return True
-        return False


### PR DESCRIPTION
closes #47 

This PR adds full support for task templates in tix

### Changes:
- `TemplateStorage` class for JSON-based storage of task templates.
- `tix template save <task_id> <name>` command to save a task as a template.
- `tix template list` command to display all saved templates.
- `tix add --template <name>` creates tasks from templates.

This enables quick reuse of common task patterns for faster task creation.

- Documentation: Updated README with usage examples for template commands.
- Tests:
      -    Pytest coverage for TemplateStorage save, load, and list.
      -    CLI tests for template save, template list, and add --template. 





## Sample:
<img width="1903" height="905" alt="Screenshot 2025-10-02 112611" src="https://github.com/user-attachments/assets/13c25bf9-3d5d-4eb3-8f80-fce7a411fcb8" />
<img width="1709" height="889" alt="Screenshot 2025-10-02 112636" src="https://github.com/user-attachments/assets/66c32256-f63f-4875-a5f1-ad664539b450" />
<img width="1495" height="701" alt="Screenshot 2025-10-02 113640" src="https://github.com/user-attachments/assets/dcdbc7fd-3ddb-4d7e-97bd-f5564b5db1a5" />
<img width="1908" height="940" alt="Screenshot 2025-10-02 132945" src="https://github.com/user-attachments/assets/4f5c5701-2046-48c9-822f-1ea0e53acbc5" />

