### PR TITLE
feat: add markdown format support to report command...  issue#16

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,22 @@ def test_add_task(runner):
             assert result.exit_code == 0
             assert 'Added task' in result.output
             assert 'Test task' in result.output
-
+def test_report_markdown(runner):
+    """Test markdown report generation"""
+    with runner.isolated_filesystem():
+        temp_storage = Path.cwd() / "tasks.json"
+        temp_storage.write_text('[]')
+        from tix.storage.json_storage import TaskStorage
+        test_storage = TaskStorage(temp_storage)
+        with patch('tix.cli.storage', test_storage):
+            runner.invoke(cli, ['add', 'High priority task', '-p', 'high', '-t', 'work'])
+            runner.invoke(cli, ['add', 'Medium task', '-p', 'medium'])
+            runner.invoke(cli, ['done', '1'])
+            result = runner.invoke(cli, ['report', '-f', 'markdown'])
+            assert result.exit_code == 0
+            assert '# TIX Task Report' in result.output
+            assert '- [ ]' in result.output 
+            assert '## Summary' in result.output
 
 def test_list_empty(runner):
     """Test listing when no tasks"""


### PR DESCRIPTION
## PR Checklist
- [x] Follows single-purpose principle
- [x] Tests pass locally
- [x] Documentation updated (if needed)

## What does this PR do?
This PR adds markdown format support to the `report` command, enabling users to export their tasks in a GitHub-friendly markdown format. Active tasks are displayed with checkbox syntax and grouped by priority, while completed tasks are shown in a clean markdown table.

## Related Issue
Closes #16

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Configuration
- [ ] Documentation

## Changes Made
- Added `markdown` option to the `--format` flag in `report` command
- Implemented checkbox syntax (`- [ ]`) for active tasks
- Added priority-based grouping with emoji indicators (🔴 High, 🟡 Medium, 🟢 Low)
- Created markdown table format for completed tasks with metadata
- Used strikethrough formatting for completed task text

## Example Output
```markdown
# TIX Task Report

**Generated:** 2025-10-02 00:00

## Summary

- **Total Tasks:** 3
- **Active:** 2
- **Completed:** 1

## Active Tasks

### 🟡 Medium Priority

- [ ] **#2** Write docs `docs`

### 🟢 Low Priority

- [ ] **#3** Review PR

## Completed Tasks

| ID | Task | Priority | Tags | Completed At |
|---|---|---|---|---|
| #1 | ~~Fix bug~~ | 🔴 high | `urgent` | 2025-10-01 23:50 |
