### PR TITLE
feat: add issue templates feature, bug, documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: "🐛 Bug report"
+about: "Report a reproducible bug"
+title: "[BUG] "
+labels: bug
+assignees: ""
+---
+
+### Current behaviour
+<!-- Describe what is happening -->
+
+### Steps to reproduce
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+### Expected outcome
+<!-- Describe what you expected to happen -->
+
+### Screenshots / Recordings
+<!-- If applicable, add screenshots or recordings to help explain your problem -->
+
+---
+
+## Acceptance Criteria
+<!-- Any specific requirements to be fulfilled to fix the issue, leave empty if not needed -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: true
+contact_links:
+  - name: "Contributor Guide"
+    url: "https://github.com/AdmGenSameer/archpkg-helper#contributing"
+    about: "Read contribution guidelines (if available)."
+template_selector:
+  - "🐛 Bug report"
+  - "📚 Documentation update"
+  - "✨ Feature request"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: "Contributor Guide"
-    url: "https://github.com/AdmGenSameer/archpkg-helper#contributing"
+    url: "https://github.com/TheDevOpsBlueprint/tix-cli#contributing"
     about: "Read contribution guidelines (if available)."
 template_selector:
   - "🐛 Bug report"

--- a/.github/ISSUE_TEMPLATE/docs_update.md
+++ b/.github/ISSUE_TEMPLATE/docs_update.md
@@ -1,0 +1,21 @@
+---
+name: "📚 Documentation update"
+about: "Report missing or incorrect documentation and suggest improvements"
+title: "[DOCS] "
+labels: documentation
+assignees: ""
+---
+
+### Current documentation
+<!-- What is missing, unclear, or incorrect? -->
+
+### Suggested improvement
+<!-- How should the documentation be improved? -->
+
+### Related areas
+<!-- Which files, sections, or pages are affected? -->
+
+---
+
+## Acceptance Criteria
+<!-- Any specific requirements to be fulfilled to fix the issue, leave empty if not needed -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: "✨ Feature request"
+about: "Suggest a new feature or enhancement"
+title: "[FEATURE] "
+labels: enhancement
+assignees: ""
+---
+
+### Problem / Motivation
+<!-- What problem does this feature solve? Why is it needed? -->
+
+### Proposed Solution
+<!-- Describe the feature you’d like to see -->
+
+### Alternatives considered
+<!-- If applicable, describe any alternative solutions or features you have considered -->
+
+---
+
+## Acceptance Criteria
+<!-- Any specific requirements to be fulfilled to fix the issue, leave empty if not needed -->


### PR DESCRIPTION
## PR Checklist
- [x] Follows single-purpose principle
- [ ] Tests pass locally
- [ ] Documentation updated (if needed)

## What does this PR do?
adding issue templates. when any contributor raises an issue, they will be asked to raise the issue in specified template for the different types of issues: `feature` `bug` and `documentation update`. this helps maintainers in triaging and also contributor gets clarity on the information to be included when they raise issue.

## Related Issue
Closes #74 

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Configuration
- [ ] Documentation

## Additional Notes
- I didn't add PR template as it's already added through someother commit.
- This contribution is a part of Hacktoberfest.
