### PR TITLE
Feature/save search filter: Add saving search filters ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,54 @@ tix backup restore <file_name>
 ```
 
 
+# 📖 Filters
+
+#### Saved Filters (Saved Searches)
+
+You can save commonly used filters so you don’t have to re-type them every time.
+
+```bash
+# Save a filter named "work" for high-priority tasks tagged "work"
+tix filter save work -t work -p high
+
+# Save filter for completed tasks
+tix filter save done-only --completed
+
+# Overwrite an existing filter (with --force)
+tix filter save work -t work -p medium --force
+````
+
+#### Listing Saved Filters
+
+```bash
+# Show all saved filters
+tix filter list
+```
+
+Example output:
+
+```
+Saved Filters:
+  • work → priority=high AND tag='work'
+  • done-only → completed
+```
+
+#### Applying Saved Filters
+
+```bash
+# Apply a saved filter
+tix filter apply --saved work
+
+# Apply directly without saving
+tix filter apply -p high -t urgent
+
+# Saved filter takes precedence over inline flags
+tix filter apply --saved work -p low   # will still use the saved 'work' filter
+```
+
+⚡ Saved filters are stored in `~/.tix/filters.json`.
+You can edit/remove the file manually, but it’s recommended to use the CLI commands.
+
 ## 🎨 Using Tab Completion
 
 Tab completion works automatically after installation:


### PR DESCRIPTION
## PR Checklist
- [x] Follows single-purpose principle  
- [x] Tests pass locally  
- [x] Documentation updated  

## What does this PR do?
Implements **Saved Filters** (saved searches) for `tix`.

**Features added**
- `tix filter save <name> <filter_params>` → Save a filter by name (e.g., priority, tag, completed/active).  
- `tix filter list` → List all saved filters with their parameters.  
- `tix filter apply --saved <name>` → Apply a saved filter.  
- `tix filter apply <filter_params>` → Apply a filter directly without saving.  
- Saved filters are stored in `~/.tix/filters.json`.  
- Overwriting filters supported via `--force`.  

## Related Issue
Closes #67 

## Type of change
- [ ] Bug fix  
- [x] New feature  
- [ ] Configuration  
- [x] Documentation  

## How to test
```bash
# Save a filter named "work" for high-priority tasks tagged "work"
tix filter save work -t work -p high

# Save filter for completed tasks
tix filter save done-only --completed

# Overwrite an existing filter
tix filter save work -t work -p medium --force

# List all saved filters
tix filter list

# Apply saved filter
tix filter apply --saved work

# Apply filter directly without saving
tix filter apply -p high -t urgent
```

## Additional Notes
- Added usage guidelines in readme regarding same
- This contribution is a part of Hacktoberfest