### PR TITLE
Feature/implement task sorting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,13 @@ tix ls
 # Show all tasks (including completed)
 tix ls --all
 tix ls -a
+
+# Show sorted tasks
+tix ls --sort-by [priority, text, id, created]
+tix ls -s [priority, text, id, created]
+
+tix ls --sort-by priority --sort-order [asc, desc]
+tix ls -s priority -o [asc, desc]
 ```
 
 #### Completing Tasks
@@ -437,7 +444,7 @@ Example structure:
 | Command | Description | Example |
 |---------|-------------|---------|
 | `add` | Add a new task | `tix add "Task" -p high -t work -f file.txt -l https://example.com` |
-| `ls` | List tasks | `tix ls --all` |
+| `ls` | List tasks | `tix ls --all --sort-by priority --sort-order asc` |
 | `done` | Complete a task | `tix done 1` |
 | `done-all` | Complete multiple tasks | `tix done-all 1 2 3` |
 | `rm` | Remove a task | `tix rm 1 -y` |

--- a/tix/utils/sort_tasks.py
+++ b/tix/utils/sort_tasks.py
@@ -1,0 +1,18 @@
+from tix.models import Task
+
+def sort_tasks(tasks: list[Task], sort_by: str = None, sort_order:str = None) -> list[Task]:
+    try:    
+        priority_order = {"low": 0, "medium": 1, "high": 2}
+        if sort_by:
+            sort_by_target = sort_by if sort_by != "created" else "created_at" # fix difference key on task model
+            is_reverse = sort_order == 'desc'
+            
+            if sort_by == "priority":
+                sorted_tasks = sorted(tasks, key=lambda t: priority_order.get(getattr(t, sort_by_target, ""), ""), reverse=is_reverse)
+            else:
+                sorted_tasks = sorted(tasks, key=lambda t: getattr(t, sort_by_target, ""), reverse=is_reverse)
+        else:
+            sorted_tasks = sorted(tasks, key=lambda t: (getattr(t, "completed", False) ,getattr(t, "id", 0)))
+    except:
+        sorted_tasks = sorted(tasks, key=lambda t: (getattr(t, "completed", False), getattr(t, "id", 0)))
+    return sorted_tasks


### PR DESCRIPTION
## PR Checklist
- [x] Follows single-purpose principle
- [x] Tests pass locally
- [x] Documentation updated (if needed)

## What does this PR do?
add task sorting options on cli command `tix ls` by key like priority, id, text, created date and also order options asc and desc. Now tix ls can add new option `--sort-by` for short `-s` and `--sort-order` or `-o`, it also handling an error for non relevant key. update docs for example sorting options

### example:
sort by priority asc:
<img width="558" height="202" alt="image" src="https://github.com/user-attachments/assets/cff308fd-5a4d-4e82-bf7d-3768f65a9856" />

sort by text asc:
<img width="561" height="210" alt="image" src="https://github.com/user-attachments/assets/24879a66-31c9-469d-87aa-a0ee5b748e05" />

sort by priority desc while show all tasks:
<img width="567" height="226" alt="image" src="https://github.com/user-attachments/assets/47386fdb-b9cc-40f0-95b3-c28fb00c3279" />

## Related Issue
Issue #66 

## Type of change
- [x] Bug fix
- [x] New feature
- [ ] Configuration
- [x] Documentation

## Testing
`tix ls -s priority -o desc`

## Note
for now i can't provide sorting by due because there no key on task models.